### PR TITLE
Use Flow's catch() operator instead of try-catch

### DIFF
--- a/app/src/main/java/dev/shreyaspatil/foodium/data/repository/NetworkBoundRepository.kt
+++ b/app/src/main/java/dev/shreyaspatil/foodium/data/repository/NetworkBoundRepository.kt
@@ -45,28 +45,22 @@ abstract class NetworkBoundRepository<RESULT, REQUEST> {
         // Emit Loading State
         emit(State.loading())
 
-        try {
-            // Emit Database content first
-            emit(State.success(fetchFromLocal().first()))
+        // Emit Database content first
+        emit(State.success(fetchFromLocal().first()))
 
-            // Fetch latest posts from remote
-            val apiResponse = fetchFromRemote()
+        // Fetch latest posts from remote
+        val apiResponse = fetchFromRemote()
 
-            // Parse body
-            val remotePosts = apiResponse.body()
+        // Parse body
+        val remotePosts = apiResponse.body()
 
-            // Check for response validation
-            if (apiResponse.isSuccessful && remotePosts != null) {
-                // Save posts into the persistence storage
-                saveRemoteData(remotePosts)
-            } else {
-                // Something went wrong! Emit Error state.
-                emit(State.error(apiResponse.message()))
-            }
-        } catch (e: Exception) {
-            // Exception occurred! Emit error
-            emit(State.error("Network error! Can't get latest posts."))
-            e.printStackTrace()
+        // Check for response validation
+        if (apiResponse.isSuccessful && remotePosts != null) {
+            // Save posts into the persistence storage
+            saveRemoteData(remotePosts)
+        } else {
+            // Something went wrong! Emit Error state.
+            emit(State.error(apiResponse.message()))
         }
 
         // Retrieve posts from persistence storage and emit
@@ -75,6 +69,10 @@ abstract class NetworkBoundRepository<RESULT, REQUEST> {
                 State.success<RESULT>(it)
             }
         )
+    }.catch { e ->
+        // Exception occurred! Emit error
+        emit(State.error("Network error! Can't get latest posts."))
+        e.printStackTrace()
     }
 
     /**


### PR DESCRIPTION
https://kotlinlang.org/docs/reference/coroutines/flow.html#exception-transparency. According to this, 
**Flows must be transparent to exceptions and it is a violation of the exception transparency to emit values in the flow { ... } builder from inside of a try/catch block. This guarantees that a collector throwing an exception can always catch it using try/catch as in the previous example.** 

I think it's better to use Kotlin Flow's built-in catch operator. This won't affect anything according to the current code but it will be helpful if there is any change in the catch() block in the future.