### PR TITLE
Add support for caching Gradle and Wrapper in GitHub Actions CI

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -1,11 +1,5 @@
 name: Build
-on:
-  pull_request:
-    branches:
-      - 'master'
-  push:
-    branches:
-      - 'master'
+on: [push, pull_request]
 
 jobs:
   build_apk:

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -19,6 +19,20 @@ jobs:
         with:
           java-version: 12
 
+      # Cache gradle
+      - name: Cache Gradle
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.gradle/wrapper/
+          key: cache-clean-wrapper-${{ runner.os }}-${{ matrix.jdk }}
+
       - name: Grant Permission to Execute
         run: chmod +x gradlew
         

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -17,6 +17,19 @@ jobs:
         with:
           java-version: 1.8
 
+      - name: Cache Gradle
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.gradle/wrapper/
+          key: cache-clean-wrapper-${{ runner.os }}-${{ matrix.jdk }}
+
       - name: Grant Permission to Execute
         run: chmod +x gradlew
 

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -9,6 +9,19 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
+      - name: Cache Gradle
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.gradle/wrapper/
+          key: cache-clean-wrapper-${{ runner.os }}-${{ matrix.jdk }}
+
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -11,7 +11,7 @@ object Testing {
 object Dependencies {
     const val kotlin = "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.72"
     const val kotlinGradle = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72"
-    const val gradle = "com.android.tools.build:gradle:4.0.0"
+    const val gradle = "com.android.tools.build:gradle:4.0.1"
     const val daggerHilt = "com.google.dagger:hilt-android-gradle-plugin:2.28-alpha"
     const val ktLint = "org.jlleitschuh.gradle:ktlint-gradle:9.2.1"
     const val materialDesign = "com.google.android.material:material:1.1.0"


### PR DESCRIPTION
In this PR:
- Added support for caching Gradle and Wrapper.
- Added support for triggering `build` CI on every branch.
