### PR TITLE
use Room suspending functions

### DIFF
--- a/app/src/main/java/dev/shreyaspatil/foodium/data/local/dao/PostsDao.kt
+++ b/app/src/main/java/dev/shreyaspatil/foodium/data/local/dao/PostsDao.kt
@@ -43,13 +43,13 @@ interface PostsDao {
      * @param posts Posts
      */
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun insertPosts(posts: List<Post>)
+    suspend fun insertPosts(posts: List<Post>)
 
     /**
      * Deletes all the posts from the [Post.TABLE_NAME] table.
      */
     @Query("DELETE FROM ${Post.TABLE_NAME}")
-    fun deleteAllPosts()
+    suspend fun deleteAllPosts()
 
     /**
      * Fetches the post from the [Post.TABLE_NAME] table whose id is [postId].

--- a/app/src/main/java/dev/shreyaspatil/foodium/data/repository/PostsRepository.kt
+++ b/app/src/main/java/dev/shreyaspatil/foodium/data/repository/PostsRepository.kt
@@ -29,10 +29,8 @@ import dev.shreyaspatil.foodium.data.local.dao.PostsDao
 import dev.shreyaspatil.foodium.data.remote.api.FoodiumService
 import dev.shreyaspatil.foodium.model.Post
 import dev.shreyaspatil.foodium.model.State
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOn
 import retrofit2.Response
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -61,7 +59,7 @@ class PostsRepository @Inject constructor(
             override fun fetchFromLocal(): Flow<List<Post>> = postsDao.getAllPosts()
 
             override suspend fun fetchFromRemote(): Response<List<Post>> = foodiumService.getPosts()
-        }.asFlow().flowOn(Dispatchers.IO)
+        }.asFlow()
     }
 
     /**


### PR DESCRIPTION


**- Use inbuilt threading support for room DB**

We do not need to create our threading model(using Dispatcher.IO). Instead, we can leverage the functionality already provided in Room library.

**- Description for the changelog**

It uses Room's inbuilt suspending functions so that we do not need to introduce our own threading model.  