### PR TITLE
Removed deprecated 'kotlin-android-extensions' plugin.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,7 +26,6 @@ plugins {
     id("com.android.application")
     id("kotlin-android")
     id("kotlin-kapt")
-    id("kotlin-android-extensions")
     id("dagger.hilt.android.plugin")
     id("org.jlleitschuh.gradle.ktlint")
 }

--- a/app/src/main/java/dev/shreyaspatil/foodium/ui/details/PostDetailsActivity.kt
+++ b/app/src/main/java/dev/shreyaspatil/foodium/ui/details/PostDetailsActivity.kt
@@ -35,7 +35,6 @@ import dev.shreyaspatil.foodium.R
 import dev.shreyaspatil.foodium.databinding.ActivityPostDetailsBinding
 import dev.shreyaspatil.foodium.model.Post
 import dev.shreyaspatil.foodium.ui.base.BaseActivity
-import kotlinx.android.synthetic.main.activity_post_details.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 @ExperimentalCoroutinesApi
@@ -50,7 +49,7 @@ class PostDetailsActivity : BaseActivity<PostDetailsViewModel, ActivityPostDetai
         super.onCreate(savedInstanceState)
         setContentView(mViewBinding.root)
 
-        setSupportActionBar(toolbar)
+        setSupportActionBar(mViewBinding.toolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
         val postId = intent.extras?.getInt(POST_ID)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/patilshreyas/Foodium/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request
-->
Removed the `kotlin-android-extensions` plugin and updated the `PostDetailsActivity` to use `mViewBinding.toolbar` instead of toolbar from `kotlinx.android.synthetic.main.activity_post_details`

