### PR TITLE
Update share button functionality to show android share sheet

### DIFF
--- a/app/src/main/java/dev/shreyaspatil/foodium/ui/details/PostDetailsActivity.kt
+++ b/app/src/main/java/dev/shreyaspatil/foodium/ui/details/PostDetailsActivity.kt
@@ -53,7 +53,7 @@ class PostDetailsActivity : BaseActivity<PostDetailsViewModel, ActivityPostDetai
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
         val postId = intent.extras?.getInt(POST_ID)
-            ?: throw IllegalArgumentException("`postId` must be non-null")
+                ?: throw IllegalArgumentException("`postId` must be non-null")
 
         initPost(postId)
     }
@@ -77,7 +77,7 @@ class PostDetailsActivity : BaseActivity<PostDetailsViewModel, ActivityPostDetai
     }
 
     override fun getViewBinding(): ActivityPostDetailsBinding =
-        ActivityPostDetailsBinding.inflate(layoutInflater)
+            ActivityPostDetailsBinding.inflate(layoutInflater)
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {

--- a/app/src/main/java/dev/shreyaspatil/foodium/ui/details/PostDetailsActivity.kt
+++ b/app/src/main/java/dev/shreyaspatil/foodium/ui/details/PostDetailsActivity.kt
@@ -24,11 +24,11 @@
 
 package dev.shreyaspatil.foodium.ui.details
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import androidx.activity.viewModels
-import androidx.core.app.ShareCompat
 import coil.load
 import dagger.hilt.android.AndroidEntryPoint
 import dev.shreyaspatil.foodium.R
@@ -87,25 +87,28 @@ class PostDetailsActivity : BaseActivity<PostDetailsViewModel, ActivityPostDetai
             }
 
             R.id.action_share -> {
-                val shareMsg = getString(
-                    R.string.share_message,
-                    post.title,
-                    post.author
-                )
-
-                val intent = ShareCompat.IntentBuilder.from(this)
-                    .setType("text/plain")
-                    .setText(shareMsg)
-                    .intent
-
-                if (intent.resolveActivity(packageManager) != null) {
-                    startActivity(intent)
-                }
+                showShareTray()
                 return true
             }
         }
 
         return super.onOptionsItemSelected(item)
+    }
+
+    private fun showShareTray() {
+        val shareMsg = getString(
+                R.string.share_message,
+                post.title,
+                post.author
+        )
+        val intent = Intent(Intent.ACTION_SEND)
+        intent.apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_TEXT, shareMsg)
+            putExtra(Intent.EXTRA_TITLE, post.title)
+        }
+
+        startActivity(Intent.createChooser(intent, null))
     }
 
     companion object {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/patilshreyas/Foodium/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**
Use the Android Sharesheet to provide the share functionality, allowing for a more modern looking share menu on Android 10 (API level 29) and above. This will also add the ability to show rich content to previews.

**- Description for the changelog**
Handles the share action by creating an Intent with `ACTION_SEND` and uses the `Intent.createChooser` to return a share sheet intent. 

**- A picture or screenshot regarding change (not mandatory but encouraged)**
On Android 10,
<img src="https://user-images.githubusercontent.com/6688825/100489972-65472880-30dd-11eb-8d76-28069b1a23c4.png" height=300 width=150>

On Android 6,
<img src="https://user-images.githubusercontent.com/6688825/100793910-772d1200-33e2-11eb-9780-fa720d5c1334.png" height=300 width=150>

Closes #48 
