### PR TITLE
[Refactor] Do not emit State from Repository

### DIFF
--- a/app/src/main/java/dev/shreyaspatil/foodium/data/repository/NetworkBoundRepository.kt
+++ b/app/src/main/java/dev/shreyaspatil/foodium/data/repository/NetworkBoundRepository.kt
@@ -56,7 +56,7 @@ abstract class NetworkBoundRepository<RESULT, REQUEST> {
             saveRemoteData(remotePosts)
         } else {
             // Something went wrong! Emit Error state.
-            emit(Resource.Error(apiResponse.message()))
+            emit(Resource.Failed(apiResponse.message()))
         }
 
         // Retrieve posts from persistence storage and emit
@@ -67,7 +67,7 @@ abstract class NetworkBoundRepository<RESULT, REQUEST> {
         )
     }.catch { e ->
         e.printStackTrace()
-        emit(Resource.Error("Network error! Can't get latest posts."))
+        emit(Resource.Failed("Network error! Can't get latest posts."))
     }
 
     /**

--- a/app/src/main/java/dev/shreyaspatil/foodium/data/repository/PostsRepository.kt
+++ b/app/src/main/java/dev/shreyaspatil/foodium/data/repository/PostsRepository.kt
@@ -28,7 +28,6 @@ import androidx.annotation.MainThread
 import dev.shreyaspatil.foodium.data.local.dao.PostsDao
 import dev.shreyaspatil.foodium.data.remote.api.FoodiumService
 import dev.shreyaspatil.foodium.model.Post
-import dev.shreyaspatil.foodium.model.State
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import retrofit2.Response
@@ -50,7 +49,7 @@ class PostsRepository @Inject constructor(
      * Fetched the posts from network and stored it in database. At the end, data from persistence
      * storage is fetched and emitted.
      */
-    fun getAllPosts(): Flow<State<List<Post>>> {
+    fun getAllPosts(): Flow<Resource<List<Post>>> {
         return object : NetworkBoundRepository<List<Post>, List<Post>>() {
 
             override suspend fun saveRemoteData(response: List<Post>) =

--- a/app/src/main/java/dev/shreyaspatil/foodium/data/repository/Resource.kt
+++ b/app/src/main/java/dev/shreyaspatil/foodium/data/repository/Resource.kt
@@ -1,0 +1,6 @@
+package dev.shreyaspatil.foodium.data.repository
+
+sealed class Resource<T> {
+    class Success<T>(val data: T) : Resource<T>()
+    class Error<T>(val message: String) : Resource<T>()
+}

--- a/app/src/main/java/dev/shreyaspatil/foodium/data/repository/Resource.kt
+++ b/app/src/main/java/dev/shreyaspatil/foodium/data/repository/Resource.kt
@@ -2,5 +2,5 @@ package dev.shreyaspatil.foodium.data.repository
 
 sealed class Resource<T> {
     class Success<T>(val data: T) : Resource<T>()
-    class Error<T>(val message: String) : Resource<T>()
+    class Failed<T>(val message: String) : Resource<T>()
 }

--- a/app/src/main/java/dev/shreyaspatil/foodium/model/State.kt
+++ b/app/src/main/java/dev/shreyaspatil/foodium/model/State.kt
@@ -68,7 +68,7 @@ sealed class State<T> {
          */
         fun <T> fromResource(resource: Resource<T>): State<T> = when (resource) {
             is Resource.Success -> success(resource.data)
-            is Resource.Error -> error(resource.message)
+            is Resource.Failed -> error(resource.message)
         }
     }
 }

--- a/app/src/main/java/dev/shreyaspatil/foodium/model/State.kt
+++ b/app/src/main/java/dev/shreyaspatil/foodium/model/State.kt
@@ -24,6 +24,8 @@
 
 package dev.shreyaspatil.foodium.model
 
+import dev.shreyaspatil.foodium.data.repository.Resource
+
 /**
  * State Management for UI & Data.
  */
@@ -33,6 +35,12 @@ sealed class State<T> {
     data class Success<T>(val data: T) : State<T>()
 
     data class Error<T>(val message: String) : State<T>()
+
+    fun isLoading(): Boolean = this is Loading
+
+    fun isSuccessful(): Boolean = this is Success
+
+    fun isFailed(): Boolean = this is Error
 
     companion object {
 
@@ -54,5 +62,13 @@ sealed class State<T> {
          */
         fun <T> error(message: String) =
             Error<T>(message)
+
+        /**
+         * Returns [State] from [Resource]
+         */
+        fun <T> fromResource(resource: Resource<T>): State<T> = when (resource) {
+            is Resource.Success -> success(resource.data)
+            is Resource.Error -> error(resource.message)
+        }
     }
 }

--- a/app/src/main/java/dev/shreyaspatil/foodium/ui/main/MainViewModel.kt
+++ b/app/src/main/java/dev/shreyaspatil/foodium/ui/main/MainViewModel.kt
@@ -34,6 +34,8 @@ import dev.shreyaspatil.foodium.model.Post
 import dev.shreyaspatil.foodium.model.State
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 
 /**
@@ -45,14 +47,14 @@ class MainViewModel @ViewModelInject constructor(private val postsRepository: Po
 
     private val _postsLiveData = MutableLiveData<State<List<Post>>>()
 
-    val postsLiveData: LiveData<State<List<Post>>>
-        get() = _postsLiveData
+    val postsLiveData: LiveData<State<List<Post>>> = _postsLiveData
 
     fun getPosts() {
         viewModelScope.launch {
-            postsRepository.getAllPosts().collect {
-                _postsLiveData.value = it
-            }
+            postsRepository.getAllPosts()
+                .onStart { _postsLiveData.value = State.loading() }
+                .map { resource -> State.fromResource(resource) }
+                .collect { state -> _postsLiveData.value = state }
         }
     }
 }


### PR DESCRIPTION
**- Summary**

Remove interference of `State` in Repository layer.

**- Description for the changelog**

Ideally, the repository should not know about State _(especially ViewState like Loading, Success, Error)_ since it's a single source of truth hence it should provide data and it should only do that. It's ViewModel's responsibility to maintain the state of the Activity. This PR removes implementations of this anti-pattern and gives responsibility to the `MainViewModel` to maintain UI State of `MainActivity`. The repository now simply returns a `Resource` which might be one of the `Success` or `Failed`.

_Read more about anti-pattern of "emitting states from repository" on the below link which is a blog published by @RivuChk_

Blog Link: https://www.rivu.dev/why-emitting-state-from-repository-is-an-ani-pattern/