### PR TITLE
Migrate to Dagger Hilt 2.31

### DIFF
--- a/app/src/androidTest/java/dev/shreyaspatil/foodium/data/local/dao/PostsDaoTest.kt
+++ b/app/src/androidTest/java/dev/shreyaspatil/foodium/data/local/dao/PostsDaoTest.kt
@@ -59,7 +59,7 @@ class PostsDaoTest {
             Post(2, "Test 2", "Test 2", "Test 3")
         )
 
-        mDatabase.getPostsDao().insertPosts(posts)
+        mDatabase.getPostsDao().addPosts(posts)
 
         val dbPosts = mDatabase.getPostsDao().getAllPosts().toList()[0]
 
@@ -74,7 +74,7 @@ class PostsDaoTest {
             Post(2, "Test 2", "Test 2", "Test 3")
         )
 
-        mDatabase.getPostsDao().insertPosts(posts)
+        mDatabase.getPostsDao().addPosts(posts)
 
         var dbPost = mDatabase.getPostsDao().getPostById(1)
         assertThat(dbPost.toList()[0], equalTo(posts[0]))

--- a/app/src/main/java/dev/shreyaspatil/foodium/data/local/dao/PostsDao.kt
+++ b/app/src/main/java/dev/shreyaspatil/foodium/data/local/dao/PostsDao.kt
@@ -43,7 +43,7 @@ interface PostsDao {
      * @param posts Posts
      */
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertPosts(posts: List<Post>)
+    suspend fun addPosts(posts: List<Post>)
 
     /**
      * Deletes all the posts from the [Post.TABLE_NAME] table.

--- a/app/src/main/java/dev/shreyaspatil/foodium/data/repository/PostRepository.kt
+++ b/app/src/main/java/dev/shreyaspatil/foodium/data/repository/PostRepository.kt
@@ -34,26 +34,31 @@ import retrofit2.Response
 import javax.inject.Inject
 import javax.inject.Singleton
 
+@Singleton
+interface PostRepository {
+    fun getAllPosts(): Flow<Resource<List<Post>>>
+    fun getPostById(postId: Int): Flow<Post>
+}
+
 /**
  * Singleton repository for fetching data from remote and storing it in database
  * for offline capability. This is Single source of data.
  */
 @ExperimentalCoroutinesApi
 @Singleton
-class PostsRepository @Inject constructor(
+class DefaultPostRepository @Inject constructor(
     private val postsDao: PostsDao,
     private val foodiumService: FoodiumService
-) {
+) : PostRepository {
 
     /**
      * Fetched the posts from network and stored it in database. At the end, data from persistence
      * storage is fetched and emitted.
      */
-    fun getAllPosts(): Flow<Resource<List<Post>>> {
+    override fun getAllPosts(): Flow<Resource<List<Post>>> {
         return object : NetworkBoundRepository<List<Post>, List<Post>>() {
 
-            override suspend fun saveRemoteData(response: List<Post>) =
-                postsDao.insertPosts(response)
+            override suspend fun saveRemoteData(response: List<Post>) = postsDao.addPosts(response)
 
             override fun fetchFromLocal(): Flow<List<Post>> = postsDao.getAllPosts()
 
@@ -67,5 +72,5 @@ class PostsRepository @Inject constructor(
      * @return [Post] data fetched from the database.
      */
     @MainThread
-    fun getPostById(postId: Int): Flow<Post> = postsDao.getPostById(postId)
+    override fun getPostById(postId: Int): Flow<Post> = postsDao.getPostById(postId)
 }

--- a/app/src/main/java/dev/shreyaspatil/foodium/di/module/FoodiumApiModule.kt
+++ b/app/src/main/java/dev/shreyaspatil/foodium/di/module/FoodiumApiModule.kt
@@ -29,13 +29,13 @@ import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ApplicationComponent
+import dagger.hilt.components.SingletonComponent
 import dev.shreyaspatil.foodium.data.remote.api.FoodiumService
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import javax.inject.Singleton
 
-@InstallIn(ApplicationComponent::class)
+@InstallIn(SingletonComponent::class)
 @Module
 class FoodiumApiModule {
 

--- a/app/src/main/java/dev/shreyaspatil/foodium/di/module/FoodiumDatabaseModule.kt
+++ b/app/src/main/java/dev/shreyaspatil/foodium/di/module/FoodiumDatabaseModule.kt
@@ -28,11 +28,11 @@ import android.app.Application
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ApplicationComponent
+import dagger.hilt.components.SingletonComponent
 import dev.shreyaspatil.foodium.data.local.FoodiumPostsDatabase
 import javax.inject.Singleton
 
-@InstallIn(ApplicationComponent::class)
+@InstallIn(SingletonComponent::class)
 @Module
 class FoodiumDatabaseModule {
 

--- a/app/src/main/java/dev/shreyaspatil/foodium/di/module/PostRepositoryModule.kt
+++ b/app/src/main/java/dev/shreyaspatil/foodium/di/module/PostRepositoryModule.kt
@@ -1,0 +1,44 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Shreyas Patil
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package dev.shreyaspatil.foodium.di.module
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.android.scopes.ViewModelScoped
+import dev.shreyaspatil.foodium.data.repository.DefaultPostRepository
+import dev.shreyaspatil.foodium.data.repository.PostRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+
+@ExperimentalCoroutinesApi
+@InstallIn(ViewModelComponent::class)
+@Module
+abstract class PostRepositoryModule {
+
+    @ViewModelScoped
+    @Binds
+    abstract fun bindPostRepository(repository: DefaultPostRepository): PostRepository
+}

--- a/app/src/main/java/dev/shreyaspatil/foodium/ui/details/PostDetailsViewModel.kt
+++ b/app/src/main/java/dev/shreyaspatil/foodium/ui/details/PostDetailsViewModel.kt
@@ -24,19 +24,21 @@
 
 package dev.shreyaspatil.foodium.ui.details
 
-import androidx.hilt.lifecycle.ViewModelInject
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
-import dev.shreyaspatil.foodium.data.repository.PostsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.shreyaspatil.foodium.data.repository.PostRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import javax.inject.Inject
 
 /**
  * ViewModel for [PostDetailsActivity]
  */
 @ExperimentalCoroutinesApi
-class PostDetailsViewModel @ViewModelInject constructor(
-    private val postsRepository: PostsRepository
+@HiltViewModel
+class PostDetailsViewModel @Inject constructor(
+    private val postRepository: PostRepository
 ) : ViewModel() {
 
-    fun getPost(id: Int) = postsRepository.getPostById(id).asLiveData()
+    fun getPost(id: Int) = postRepository.getPostById(id).asLiveData()
 }

--- a/app/src/main/java/dev/shreyaspatil/foodium/ui/main/MainViewModel.kt
+++ b/app/src/main/java/dev/shreyaspatil/foodium/ui/main/MainViewModel.kt
@@ -24,12 +24,12 @@
 
 package dev.shreyaspatil.foodium.ui.main
 
-import androidx.hilt.lifecycle.ViewModelInject
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import dev.shreyaspatil.foodium.data.repository.PostsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.shreyaspatil.foodium.data.repository.PostRepository
 import dev.shreyaspatil.foodium.model.Post
 import dev.shreyaspatil.foodium.model.State
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -37,12 +37,14 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 /**
  * ViewModel for [MainActivity]
  */
 @ExperimentalCoroutinesApi
-class MainViewModel @ViewModelInject constructor(private val postsRepository: PostsRepository) :
+@HiltViewModel
+class MainViewModel @Inject constructor(private val postRepository: PostRepository) :
     ViewModel() {
 
     private val _postsLiveData = MutableLiveData<State<List<Post>>>()
@@ -51,7 +53,7 @@ class MainViewModel @ViewModelInject constructor(private val postsRepository: Po
 
     fun getPosts() {
         viewModelScope.launch {
-            postsRepository.getAllPosts()
+            postRepository.getAllPosts()
                 .onStart { _postsLiveData.value = State.loading() }
                 .map { resource -> State.fromResource(resource) }
                 .collect { state -> _postsLiveData.value = state }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -9,10 +9,10 @@ object Testing {
 }
 
 object Dependencies {
-    const val kotlin = "org.jetbrains.kotlin:kotlin-stdlib:1.4.20"
-    const val kotlinGradle = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.20"
+    const val kotlin = "org.jetbrains.kotlin:kotlin-stdlib:1.4.21"
+    const val kotlinGradle = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.21"
     const val gradle = "com.android.tools.build:gradle:4.1.1"
-    const val daggerHilt = "com.google.dagger:hilt-android-gradle-plugin:2.28-alpha"
+    const val daggerHilt = "com.google.dagger:hilt-android-gradle-plugin:2.31-alpha"
     const val ktLint = "org.jlleitschuh.gradle:ktlint-gradle:9.2.1"
     const val materialDesign = "com.google.android.material:material:1.2.0"
     const val materialDialog = "com.shreyaspatil:MaterialDialog:2.1"
@@ -25,10 +25,10 @@ object Lifecycle {
 }
 
 object Hilt {
-    const val daggerCompiler = "com.google.dagger:hilt-android-compiler:2.28-alpha"
-    const val hiltCompiler = "androidx.hilt:hilt-compiler:1.0.0-alpha01"
-    const val hiltViewModel = "androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha01"
-    const val hiltAndroid = "com.google.dagger:hilt-android:2.28-alpha"
+    const val daggerCompiler = "com.google.dagger:hilt-android-compiler:2.31-alpha"
+    const val hiltCompiler = "androidx.hilt:hilt-compiler:1.0.0-alpha02"
+    const val hiltViewModel = "androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha02"
+    const val hiltAndroid = "com.google.dagger:hilt-android:2.31-alpha"
 }
 
 object Moshi {
@@ -55,7 +55,7 @@ object Android {
 }
 
 object Room {
-    const val compiler = "androidx.room:room-compiler:2.2.5"
-    const val ktx = "androidx.room:room-ktx:2.2.5"
-    const val runtime = "androidx.room:room-runtime:2.2.5"
+    const val compiler = "androidx.room:room-compiler:2.2.6"
+    const val ktx = "androidx.room:room-ktx:2.2.6"
+    const val runtime = "androidx.room:room-runtime:2.2.6"
 }


### PR DESCRIPTION
**- Summary**

- Migrate to Dagger Hilt 2.31

**- Description for the changelog**

- Bumped Kotlin version to 1.4.21
- Bumped Room DB version to 2.6.0
- Bumped Dagger version to 2.31-alpha and hilt to 1.0.0-alpha02
- Use `@HiltViewModel` annotation to inject ViewModels
- Replace installing the DI modules in `ApplicationComponent` with `SingletonComponent`
- Create an interface for `PostRepository` (_Earlier it was only a class. Made this change so that in future it would be easy to test the components of the application_).