### PR TITLE
Use @AssistedInject for PostDetailsViewModel

### DIFF
--- a/app/src/main/java/dev/shreyaspatil/foodium/data/repository/PostRepository.kt
+++ b/app/src/main/java/dev/shreyaspatil/foodium/data/repository/PostRepository.kt
@@ -32,9 +32,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import retrofit2.Response
 import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
 interface PostRepository {
     fun getAllPosts(): Flow<Resource<List<Post>>>
     fun getPostById(postId: Int): Flow<Post>
@@ -45,7 +43,6 @@ interface PostRepository {
  * for offline capability. This is Single source of data.
  */
 @ExperimentalCoroutinesApi
-@Singleton
 class DefaultPostRepository @Inject constructor(
     private val postsDao: PostsDao,
     private val foodiumService: FoodiumService

--- a/app/src/main/java/dev/shreyaspatil/foodium/di/module/PostRepositoryModule.kt
+++ b/app/src/main/java/dev/shreyaspatil/foodium/di/module/PostRepositoryModule.kt
@@ -27,18 +27,22 @@ package dev.shreyaspatil.foodium.di.module
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ViewModelComponent
-import dagger.hilt.android.scopes.ViewModelScoped
+import dagger.hilt.android.components.ActivityRetainedComponent
+import dagger.hilt.android.scopes.ActivityRetainedScoped
 import dev.shreyaspatil.foodium.data.repository.DefaultPostRepository
 import dev.shreyaspatil.foodium.data.repository.PostRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
+/**
+ * Currently PostRepository is only used in ViewModels.
+ * PostDetailsViewModel is not injected using @HiltViewModel so can't install in ViewModelComponent.
+ */
 @ExperimentalCoroutinesApi
-@InstallIn(ViewModelComponent::class)
+@InstallIn(ActivityRetainedComponent::class)
 @Module
 abstract class PostRepositoryModule {
 
-    @ViewModelScoped
+    @ActivityRetainedScoped
     @Binds
     abstract fun bindPostRepository(repository: DefaultPostRepository): PostRepository
 }

--- a/app/src/main/java/dev/shreyaspatil/foodium/ui/details/PostDetailsViewModel.kt
+++ b/app/src/main/java/dev/shreyaspatil/foodium/ui/details/PostDetailsViewModel.kt
@@ -25,20 +25,39 @@
 package dev.shreyaspatil.foodium.ui.details
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.asLiveData
-import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import dev.shreyaspatil.foodium.data.repository.PostRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import javax.inject.Inject
 
 /**
  * ViewModel for [PostDetailsActivity]
  */
 @ExperimentalCoroutinesApi
-@HiltViewModel
-class PostDetailsViewModel @Inject constructor(
-    private val postRepository: PostRepository
+class PostDetailsViewModel @AssistedInject constructor(
+    postRepository: PostRepository,
+    @Assisted postId: Int
 ) : ViewModel() {
 
-    fun getPost(id: Int) = postRepository.getPostById(id).asLiveData()
+    val post = postRepository.getPostById(postId).asLiveData()
+
+    @AssistedFactory
+    interface PostDetailsViewModelFactory {
+        fun create(postId: Int): PostDetailsViewModel
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    companion object {
+        fun provideFactory(
+            assistedFactory: PostDetailsViewModelFactory,
+            postId: Int
+        ): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
+            override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+                return assistedFactory.create(postId) as T
+            }
+        }
+    }
 }


### PR DESCRIPTION
**- Summary**

Use `AssistedInject` for PostDetailsViewModel and use Factory for creating an instance of a ViewModel.

**- Description for the changelog**

- Install and bind `PostRepository` as `ActivityRetainedComponent`.
- Get `postId` from constructor parameter in PostDetailsViewModel using assisted injection.