### PR TITLE
Use of distinctUntilChanged()

### DIFF
--- a/app/src/main/java/dev/shreyaspatil/foodium/data/local/dao/PostsDao.kt
+++ b/app/src/main/java/dev/shreyaspatil/foodium/data/local/dao/PostsDao.kt
@@ -30,7 +30,6 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import dev.shreyaspatil.foodium.model.Post
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.distinctUntilChanged
 
 /**
  * Data Access Object (DAO) for [dev.shreyaspatil.foodium.data.local.FoodiumPostsDatabase]

--- a/app/src/main/java/dev/shreyaspatil/foodium/data/local/dao/PostsDao.kt
+++ b/app/src/main/java/dev/shreyaspatil/foodium/data/local/dao/PostsDao.kt
@@ -30,6 +30,7 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import dev.shreyaspatil.foodium.model.Post
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
 
 /**
  * Data Access Object (DAO) for [dev.shreyaspatil.foodium.data.local.FoodiumPostsDatabase]
@@ -58,6 +59,8 @@ interface PostsDao {
      */
     @Query("SELECT * FROM ${Post.TABLE_NAME} WHERE ID = :postId")
     fun getPostById(postId: Int): Flow<Post>
+
+    fun getPostByIdUntilChanged(id: Int) = getPostById(id).distinctUntilChanged()
 
     /**
      * Fetches all the posts from the [Post.TABLE_NAME] table.

--- a/app/src/main/java/dev/shreyaspatil/foodium/data/local/dao/PostsDao.kt
+++ b/app/src/main/java/dev/shreyaspatil/foodium/data/local/dao/PostsDao.kt
@@ -60,8 +60,6 @@ interface PostsDao {
     @Query("SELECT * FROM ${Post.TABLE_NAME} WHERE ID = :postId")
     fun getPostById(postId: Int): Flow<Post>
 
-    fun getPostByIdUntilChanged(id: Int) = getPostById(id).distinctUntilChanged()
-
     /**
      * Fetches all the posts from the [Post.TABLE_NAME] table.
      * @return [Flow]

--- a/app/src/main/java/dev/shreyaspatil/foodium/data/repository/PostRepository.kt
+++ b/app/src/main/java/dev/shreyaspatil/foodium/data/repository/PostRepository.kt
@@ -69,5 +69,5 @@ class DefaultPostRepository @Inject constructor(
      * @return [Post] data fetched from the database.
      */
     @MainThread
-    override fun getPostById(postId: Int): Flow<Post> = postsDao.getPostById(postId)
+    override fun getPostById(postId: Int): Flow<Post> = postsDao.getPostByIdUntilChanged(postId)
 }

--- a/app/src/main/java/dev/shreyaspatil/foodium/data/repository/PostRepository.kt
+++ b/app/src/main/java/dev/shreyaspatil/foodium/data/repository/PostRepository.kt
@@ -31,7 +31,6 @@ import dev.shreyaspatil.foodium.model.Post
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.distinctUntilChangedBy
 import retrofit2.Response
 import javax.inject.Inject
 

--- a/app/src/main/java/dev/shreyaspatil/foodium/data/repository/PostRepository.kt
+++ b/app/src/main/java/dev/shreyaspatil/foodium/data/repository/PostRepository.kt
@@ -30,6 +30,8 @@ import dev.shreyaspatil.foodium.data.remote.api.FoodiumService
 import dev.shreyaspatil.foodium.model.Post
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.distinctUntilChangedBy
 import retrofit2.Response
 import javax.inject.Inject
 
@@ -69,5 +71,5 @@ class DefaultPostRepository @Inject constructor(
      * @return [Post] data fetched from the database.
      */
     @MainThread
-    override fun getPostById(postId: Int): Flow<Post> = postsDao.getPostByIdUntilChanged(postId)
+    override fun getPostById(postId: Int): Flow<Post> = postsDao.getPostById(postId).distinctUntilChanged()
 }


### PR DESCRIPTION
In case updating any unrelated row and querying for a post with row id will trigger the query again. Use of  `distinctUntilChaged()` will avoid this. More info at https://medium.com/androiddevelopers/room-flow-273acffe5b57