### PR TITLE
Implying the use `NetworkBoundResource` instead of class representation.

### DIFF
--- a/app/src/main/java/dev/shreyaspatil/foodium/data/repository/NetworkBoundResource.kt
+++ b/app/src/main/java/dev/shreyaspatil/foodium/data/repository/NetworkBoundResource.kt
@@ -24,6 +24,8 @@
 
 package dev.shreyaspatil.foodium.data.repository
 
+import androidx.annotation.MainThread
+import androidx.annotation.WorkerThread
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.*
 import retrofit2.Response
@@ -36,9 +38,9 @@ import retrofit2.Response
  */
 @ExperimentalCoroutinesApi
 inline fun <RESULT, REQUEST> networkBoundResource(
-    crossinline fetchFromLocal: () -> Flow<RESULT>,
-    crossinline fetchFromRemote: suspend () -> Response<REQUEST>,
-    crossinline saveRemoteData: suspend (response: REQUEST) -> Unit,
+    @MainThread crossinline fetchFromLocal: () -> Flow<RESULT>,
+    @MainThread crossinline fetchFromRemote: suspend () -> Response<REQUEST>,
+    @WorkerThread crossinline saveRemoteData: suspend (response: REQUEST) -> Unit,
 ): Flow<Resource<RESULT>> {
     return flow<Resource<RESULT>> {
 

--- a/app/src/main/java/dev/shreyaspatil/foodium/data/repository/PostRepository.kt
+++ b/app/src/main/java/dev/shreyaspatil/foodium/data/repository/PostRepository.kt
@@ -54,14 +54,11 @@ class DefaultPostRepository @Inject constructor(
      * storage is fetched and emitted.
      */
     override fun getAllPosts(): Flow<Resource<List<Post>>> {
-        return object : NetworkBoundRepository<List<Post>, List<Post>>() {
-
-            override suspend fun saveRemoteData(response: List<Post>) = postsDao.addPosts(response)
-
-            override fun fetchFromLocal(): Flow<List<Post>> = postsDao.getAllPosts()
-
-            override suspend fun fetchFromRemote(): Response<List<Post>> = foodiumService.getPosts()
-        }.asFlow()
+        return networkBoundResource(
+            fetchFromLocal = { postsDao.getAllPosts() },
+            fetchFromRemote = { foodiumService.getPosts() },
+            saveRemoteData = { postsDao.addPosts(it) }
+        )
     }
 
     /**


### PR DESCRIPTION
**- Summary**

This PR doesn't modify any workflow but changes how `PostRepository.getAllPosts` is implemented. Instead of implementing an anonymous `NetworkBoundRepository` object wouldn't it be better to inline it all with a function. This would reduce object creation & also improve code readability (for eg: In the previous implementation, the `asFlow` call was not quick to notice, a Java pattern maybe).

Looking forward to your thoughts!

**- Description for the changelog**

- Modified `PostRepository.getAllPost` method & added `NetworkBoundResource`.