### PR TITLE
Replace Junit AssertThat with Google Truth AssertThat

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -138,6 +138,7 @@ dependencies {
     testImplementation(Testing.room)
     testImplementation(Testing.okHttp)
     testImplementation(Testing.jUnit)
+    testImplementation(Testing.truth)
 
     // Android Testing
     androidTestImplementation(Testing.extJUnit)

--- a/app/src/test/java/dev/shreyaspatil/foodium/data/remote/api/FoodiumServiceTest.kt
+++ b/app/src/test/java/dev/shreyaspatil/foodium/data/remote/api/FoodiumServiceTest.kt
@@ -25,6 +25,7 @@
 package dev.shreyaspatil.foodium.data.remote.api
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import kotlinx.coroutines.runBlocking
@@ -32,10 +33,7 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okio.buffer
 import okio.source
-import org.hamcrest.CoreMatchers.`is`
-import org.hamcrest.core.IsNull.notNullValue
 import org.junit.After
-import org.junit.Assert.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -78,9 +76,9 @@ class FoodiumServiceTest {
         enqueueResponse("posts.json")
         val posts = service.getPosts().body()
 
-        assertThat(posts, notNullValue())
-        assertThat(posts!!.size, `is`(2))
-        assertThat(posts[0].title, `is`("Title 1"))
+        assertThat(posts).isNotNull()
+        assertThat(posts!!.size).isEqualTo(2)
+        assertThat(posts[0].title).isEqualTo("Title 1")
     }
 
     private fun enqueueResponse(fileName: String, headers: Map<String, String> = emptyMap()) {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -6,6 +6,7 @@ object Testing {
     const val espresso = "androidx.test.espresso:espresso-core:3.3.0"
     const val okHttp = "com.squareup.okhttp3:mockwebserver:4.9.0"
     const val core = "androidx.arch.core:core-testing:2.1.0"
+    const val truth = "com.google.truth:truth:1.1.3"
 }
 
 object Dependencies {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/patilshreyas/Foodium/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

Junit AssertThat is deprecated so i use Google truth instead of it.

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request
-->

**- A picture or screenshot regarding change (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/30105033/132946940-720190cf-27e7-42c2-b4ad-32aabc10679f.png)
