### PR TITLE
Update target and compile SDK versions to API 31

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -31,13 +31,13 @@ plugins {
 }
 
 android {
-    compileSdkVersion(30)
+    compileSdkVersion(31)
     buildToolsVersion("30.0.3")
 
     defaultConfig {
         applicationId = "dev.shreyaspatil.foodium"
         minSdkVersion(21)
-        targetSdkVersion(30)
+        targetSdkVersion(31)
         versionCode = 1
         versionName = "1.0"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,7 +38,8 @@
         android:supportsRtl="true">
         <activity
             android:name=".ui.main.MainActivity"
-            android:theme="@style/AppTheme.Splash">
+            android:theme="@style/AppTheme.Splash"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -47,7 +48,8 @@
         </activity>
         <activity
             android:name=".ui.details.PostDetailsActivity"
-            android:theme="@style/AppTheme.NoActionBar">
+            android:theme="@style/AppTheme.NoActionBar"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
**- Summary**

API 31 update will be required to keep the app up-to-date. For example, if you want to use lifecycle-runtime-ktx library, you need to set API levels as 31.

**- Description for the changelog**

Update target and compile SDK versions to API 31. "Exported" attribute in manifest files is a must for all of the activities for API 31 migration.
