### PR TITLE
Replace launchWhenStarted with repeatOnLifecycle to collect flows

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -104,6 +104,7 @@ dependencies {
     // Architecture Components
     implementation(Lifecycle.viewModel)
     implementation(Lifecycle.liveData)
+    implementation(Lifecycle.runtimeKtx)
 
     // Room components
     implementation(Room.runtime)

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -23,6 +23,7 @@ object Dependencies {
 object Lifecycle {
     const val viewModel = "androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0"
     const val liveData = "androidx.lifecycle:lifecycle-livedata-ktx:2.2.0"
+    const val runtimeKtx = "androidx.lifecycle:lifecycle-runtime-ktx:2.4.0"
 }
 
 object Hilt {


### PR DESCRIPTION
**- Summary**

If we use launchWhenStarted, the collection will stop when the app goes to background but the producer(upstream) will continue running which may result with waste of resource by emitting value even if the app goes to background.

My previous PR #77(API 31 Migration) should be merged to compile this PR because the lifecycle-runtime-ktx library needs API 31 migration for the target SDK.

Explanation by Manuel Vicente Vivo: https://www.youtube.com/watch?v=fSB6_KE95bU&list=WL&t=651s

**- Description for the changelog**

Replace launchWhenStarted with repeatOnLifecycle
