### PR TITLE
Fixes #79: Could not find com.shreyaspatil:MaterialDialog:2.1 

### DIFF
--- a/app/src/main/java/dev/shreyaspatil/foodium/ui/main/MainActivity.kt
+++ b/app/src/main/java/dev/shreyaspatil/foodium/ui/main/MainActivity.kt
@@ -37,8 +37,8 @@ import androidx.core.app.ActivityOptionsCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import com.shreyaspatil.MaterialDialog.MaterialDialog
 import dagger.hilt.android.AndroidEntryPoint
+import dev.shreyaspatil.MaterialDialog.MaterialDialog
 import dev.shreyaspatil.foodium.R
 import dev.shreyaspatil.foodium.databinding.ActivityMainBinding
 import dev.shreyaspatil.foodium.model.Post

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -16,7 +16,7 @@ object Dependencies {
     const val daggerHilt = "com.google.dagger:hilt-android-gradle-plugin:2.31-alpha"
     const val ktLint = "org.jlleitschuh.gradle:ktlint-gradle:9.2.1"
     const val materialDesign = "com.google.android.material:material:1.2.0"
-    const val materialDialog = "com.shreyaspatil:MaterialDialog:2.1"
+    const val materialDialog = "dev.shreyaspatil.MaterialDialog:MaterialDialog:2.2.3"
     const val coil = "io.coil-kt:coil:1.0.0"
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/patilshreyas/Foodium/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

Fixes #79 

**- Summary**
The dependency `com.shreyaspatil:MaterialDialog:2.1` no longer exists. It has been migrated to a new namespace: `dev.shreyaspatil.material-dialogs:material-dialog`. 

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Description for the changelog**
Updated the MaterialDialog dependency to use the new namespace and artifact path. The previous version `com.shreyaspatil:MaterialDialog:2.1` is deprecated and unavailable, leading to build failures. Replaced it with the updated dependency `dev.shreyaspatil.material-dialogs:material-dialog:<latest_version>`.
<!--
Write a short (one line) summary that describes the changes in this
pull request
-->

**- A picture or screenshot regarding change (not mandatory but encouraged)**
![Screenshot_20250614_171054](https://github.com/user-attachments/assets/1e1b62eb-590a-45e3-8598-24618f869bfe)
